### PR TITLE
add binder badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # PSCAN
+
+
+Try it with Binder:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/SystemsBiologist/PSCAN/master)


### PR DESCRIPTION
This badge points to master of this repo. When a tag is published, either this badge should be updated to point to the tag, or an additional badge added with the tag URL. The tag URL would be the same as this one, replacing `master` with the tag name.